### PR TITLE
Delay 5s if config file not created yet (akash)

### DIFF
--- a/deployments/akash.yaml
+++ b/deployments/akash.yaml
@@ -4,11 +4,13 @@ version: "2.0"
 services:
   bot:
     image: ghcr.io/starship-ibc/stargaze-floor-bot:dev
+    env:
+      - "DISCORD_KEY=secret"
     command:
       - "sh"
       - "-c"
     args:
-      - "echo \"discord_key: \\\"key\\\"\n\" > config.yaml && python -m stargazefloorbot"
+      - "echo \"log_level: \\\"INFO\\\"\n\" > config.yaml"
       
     # Currently, Akash requires that we have at least 1 global port
     # even though we aren't using it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stargazefloorbot"
-version = "1.0.1"
+version = "1.0.2"
 description = "Gets floor information for stargaze collections."
 authors = ["Starship IBC <shrugs.rest0x@icloud.com>"]
 

--- a/stargazefloorbot/config/config.py
+++ b/stargazefloorbot/config/config.py
@@ -1,4 +1,6 @@
 import logging
+import os
+from time import time
 from typing import List
 
 import yaml
@@ -24,6 +26,11 @@ class Config:
     @classmethod
     def from_yaml(cls, yaml_file):
         LOG.info(f"Loading configuration from file {yaml_file}")
+
+        if not os.path.exists(yaml_file):
+            LOG.warning(f"File {yaml_file} not found. Waiting 5 seconds.")
+            time.sleep(5)
+
         with open(yaml_file) as f:
             values = yaml.safe_load(f)
 


### PR DESCRIPTION
Akash needs to create the config file on boot, but it's possible the python app will start running before the config file is created, so this adds a 5 second delay if the file is not immediately detected. This should be plenty of time for file to be created.